### PR TITLE
Update to Slangify, adapt to ::Postfix changes

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,9 @@
     "Matthew Stephen Stuckwisch"
   ],
   "auth": "zef:guifa",
-  "depends": [],
+  "depends": [
+    "Slangify:ver<0.0.3+>:auth<zef:lizmat>"
+  ],
   "build-depends": [],
   "test-depends": [],
   "provides": {

--- a/lib/Polyglot/Brainfuck.rakumod
+++ b/lib/Polyglot/Brainfuck.rakumod
@@ -1,11 +1,5 @@
 use v6.d;
-sub EXPORT(|) {
-    use Polyglot::Brainfuck::Grammar;
-    use Polyglot::Brainfuck::Actions;
+use Polyglot::Brainfuck::Grammar;
+use Polyglot::Brainfuck::Actions;
 
-    $*LANG.define_slang:
-            'MAIN',
-            $*LANG.slang_grammar('MAIN').^mixin(BFGrammarMixin),
-            $*LANG.slang_actions('MAIN').^mixin(BFActionMixin);
-    Map.new
-}
+use Slangify BFGrammarMixin, BFActionMixin;

--- a/lib/Polyglot/Brainfuck/Actions.rakumod
+++ b/lib/Polyglot/Brainfuck/Actions.rakumod
@@ -91,7 +91,7 @@ proto method BF-command { * }
 method BF-command:sym<+> (Mu $/) {
     make RakuAST::Statement::Expression.new(
         expression => RakuAST::ApplyPostfix.new(
-            postfix => RakuAST::Postfix.new('++'),
+            postfix => RakuAST::Postfix.new(:operator<++>),
             operand => MemLoc
         )
     )
@@ -101,7 +101,7 @@ method BF-command:sym<+> (Mu $/) {
 method BF-command:sym<-> (Mu $/) {
     make RakuAST::Statement::Expression.new( expression =>
         RakuAST::ApplyPostfix.new(
-           postfix => RakuAST::Postfix.new('--'),
+           postfix => RakuAST::Postfix.new(:operator<-->),
            operand => MemLoc
         )
     )
@@ -110,7 +110,7 @@ method BF-command:sym«<» (Mu $/) {
     make RakuAST::Statement::Expression.new(
         expression => RakuAST::ApplyPostfix.new(
             operand => Pointer,
-            postfix => RakuAST::Postfix.new('--')
+            postfix => RakuAST::Postfix.new(:operator<-->)
         )
     )
 }
@@ -118,7 +118,7 @@ method BF-command:sym«>» (Mu $/) {
     make RakuAST::Statement::Expression.new(
         expression => RakuAST::ApplyPostfix.new(
             operand => Pointer,
-            postfix => RakuAST::Postfix.new('++')
+            postfix => RakuAST::Postfix.new(:operator<++>)
         )
     )
 }


### PR DESCRIPTION
The interface to RakuAST::Postfix was changed from a pure positional one, to one requiring named arguments.

To simplify matters Slangify was introduced as a dependency.